### PR TITLE
Convert supervisor from multi-agent to single agent

### DIFF
--- a/backend/agents/soc_coverage.py
+++ b/backend/agents/soc_coverage.py
@@ -27,7 +27,8 @@ Take a deep breath and think step by step about how to best accomplish this goal
 - Identify the detection mechanism responsible for addressing the particular threat scenario.
 
 # INSTRUCTIONS
-Based on the rules retrieved from the Security Operations Center (SOC), evaluate the coverage of current SOC operations.
+Based on the rules retrieved from the Security Operations Center (SOC) listed below, evaluate the coverage of current SOC operations.
+{rules}
 
 # OUTPUT
 Format the output into the following three sections.
@@ -123,6 +124,16 @@ async def get_soc_rules()-> str:
         rules = await client.get_resources(server_name="detection-engineering", uris="data://deployed-rules")
         print("Obtained rules")
         return rules[0].as_string()
+    
+@tool
+def get_soc_coverage(rules):
+    """
+    Use to get the Security Operations Center (SOC) coverage given a set of rules
+    """
+    prompt = PromptTemplate.from_template(system_prompt)
+    chain = prompt | llm
+    return chain.invoke(dict(rules=rules)).content
+
         
 async def main(agent):        
     TTP = 'T1547.001: Registry Run Keys / Startup Folder'

--- a/test.py
+++ b/test.py
@@ -1,0 +1,22 @@
+import asyncio
+
+from backend.agents import supervisor
+
+if __name__ == "__main__":
+    def print_stream(stream):
+        for s in stream:
+            message = s["messages"][-1]
+            if isinstance(message, tuple): print(message)
+            else: message.pretty_print()
+    
+    async def main():
+        inputs = dict(messages=[("user", "am I covered against DLL sideloading?")])
+        async for event in supervisor.astream(inputs, stream_mode="values"):
+            message = event["messages"][-1]
+            try:
+                if isinstance(message, tuple): print(message)
+                else: message.pretty_print()
+            except:
+                print(message)
+    
+    asyncio.run(main())


### PR DESCRIPTION
Implemented SOC coverage and rules as tools, to be invoked by a single agent, instead of using them as multiple separate agents orchestrated by a supervisor.